### PR TITLE
Fix typo in 'cdse-stagging' connection URL condition

### DIFF
--- a/src/eo_processing/utils/helper.py
+++ b/src/eo_processing/utils/helper.py
@@ -24,7 +24,7 @@ def init_connection(provider: str) -> openeo.Connection :
         connection = openeo.connect("https://openeo-dev.vito.be").authenticate_oidc()
     elif provider == 'cdse':
         connection = openeo.connect(url="openeo.dataspace.copernicus.eu").authenticate_oidc()
-    elif provider == 'cdse-staging':
+    elif provider == 'cdse-stagging':
         connection = openeo.connect(url='openeo-staging.dataspace.copernicus.eu').authenticate_oidc()
     else:
         print('currently no specific connections to backends like creodias and sentinelhub are setup.')


### PR DESCRIPTION
Corrected the misspelled 'cdse-stagging' in the helper function to ensure accurate backend connections for the staging environment. This prevents potential misconfigurations or runtime issues.