### PR TITLE
Update job status handling to include finished state

### DIFF
--- a/src/eo_processing/utils/jobmanager.py
+++ b/src/eo_processing/utils/jobmanager.py
@@ -303,9 +303,10 @@ class WeedJobManager(MultiBackendJobManager):
 
                 logger.info(f"Status of job {job_id!r} (on backend {backend_name}) is {new_status!r} (previously {previous_status!r})")
 
-                if previous_status in {"created", "queued"} and new_status == "running":
-                    stats["job started running"] += 1
-                    active.loc[i, "running_start_time"] = rfc3339.utcnow()
+                if previous_status in {"created", "queued"} and new_status in {"running", "finished" }:
+                    if pd.isnull(active.loc[i, "running_start_time"]):
+                        stats["job started running"] += 1
+                        active.loc[i, "running_start_time"] = rfc3339.utcnow()
 
                 if new_status == "finished" and previous_status != "downloading":
                     stats["job finished"] += 1


### PR DESCRIPTION
Modified the logic to track the running start time for jobs transitioning to either "running" or "finished" states. This ensures accurate tracking when the running start time was previously unset.