### PR TITLE
Update job status colors and handle missing mappings

### DIFF
--- a/src/eo_processing/utils/jobmanager.py
+++ b/src/eo_processing/utils/jobmanager.py
@@ -469,10 +469,17 @@ class WeedJobManager(MultiBackendJobManager):
                       "skipped": 'darkorange',
                       "downloading": 'lightgreen',
                       "finished": 'green',
-                      "download_error" : "lightred",
+                      "error_downloading" : "lightred",
                       "error": 'darkred',
+                      "error_openeo": 'darkred',
+                      "OOM": 'darkred',
+                      "NoDataAvailable": 'darkred',
+                      "orfeo_error": 'darkred',
+                      "no_VH_band": 'darkred',
+                      "no_tiff_in_S1": 'darkred',
                       "canceled": 'magenta'}
         status_df['color'] = status_df['status'].map(color_dict)
+        status_df['color'] = status_df['color'].fillna('black')
 
         # plot the tiles with their status color
         fig, ax = plt.subplots()


### PR DESCRIPTION
Renamed and added new job statuses to the color mapping in `jobmanager.py` for improved status tracking. Introduced a default 'black' color for unmapped statuses to prevent potential errors. These changes enhance the visualization and error handling of job status updates.