### PR TITLE
Update dependencies, bump version, and add metadata utility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rasterio>=1.3.11
-openeo>=0.37.0
+openeo==0.37.0
 geopandas>=1.0.1
 notebook>=7.2.2
 matplotlib>=3.9.2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=True,
     install_requires=[
         "rasterio>=1.3.11",
-        "openeo>=0.37.0",
+        "openeo==0.37.0",
         "geopandas>=1.0.1",
         "notebook>=7.2.2",
         "matplotlib>=3.9.2",

--- a/src/eo_processing/_version.py
+++ b/src/eo_processing/_version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/src/eo_processing/utils/metadata.py
+++ b/src/eo_processing/utils/metadata.py
@@ -1,0 +1,32 @@
+from eo_processing import __version__ as eo_processing_version
+from typing import Dict, List, Tuple, Optional
+from datetime import datetime
+from openeo import __version__ as openEO_version
+
+def get_base_metadata(project: str = 'WEED') -> Dict[str, str]:
+    """
+    Prepares metadata for openEO DataCubes saved as GeoTiff.
+
+    This function generates metadata as a dictionary containing tags and
+    their values. Depending on the input project name, it populates the
+    metadata with specific details, such as copyright information, platform
+    used, references, and producer details.
+
+    :param project: A string specifying the name of the project for which
+        metadata needs generation. Defaults to 'WEED'.
+    :return: A dictionary where keys are metadata tags and values are their
+        respective details, populated for the specified project.
+    """
+    if project == 'WEED':
+        file_metadata = {
+            "copyright": "WEED project 2024 / Contains modified Copernicus Sentinel data processed by WEED consortium",
+            "creation_time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "processing_platform": f"openEO platform - client version: {openEO_version}",
+            "PROCESSING_SOFTWARE": f"eo_processing, version {eo_processing_version}",
+            "references": "https://esa-worldecosystems.org/",
+            "producer": "VITO NV"
+        }
+    else:
+        file_metadata = {}
+
+    return file_metadata


### PR DESCRIPTION
Pinned `openeo` dependency to a specific version, updated the package version to `0.2.2`, and introduced a utility for generating metadata for GeoTiff outputs. These changes ensure compatibility, proper version tracking, and improved metadata support for the WEED project.