### PR TITLE
Update key 'epsg' to 'crs' in return dictionary

### DIFF
--- a/scripts/global_20x20km_UTM_tiling-grid.py
+++ b/scripts/global_20x20km_UTM_tiling-grid.py
@@ -89,7 +89,7 @@ for UTMzone in lZones:
             'south': math.floor(row.geometry.bounds[1] / 100) * 100.,
             'east': math.ceil(row.geometry.bounds[2] / 100) * 100.,
             'north': math.ceil(row.geometry.bounds[3] / 100) * 100.,
-            'epsg': epsg
+            'crs': epsg
         }, axis=1
     )
 


### PR DESCRIPTION
Replaced the 'epsg' key with 'crs' in the output dictionary for consistency and clarity. This ensures better alignment with standard naming practices for coordinate reference systems.