### PR TITLE
Fix handling of missing VH data in preprocessing

### DIFF
--- a/src/eo_processing/openeo/preprocessing.py
+++ b/src/eo_processing/openeo/preprocessing.py
@@ -83,6 +83,9 @@ def extract_S1_datacube(
     else:
         properties = {}
 
+    # fix no-VH-data issue
+    properties.update({"polarisation": lambda pol: pol == "VV&VH"})
+
     # Load collection
     bands = connection.load_collection(S1_collection,
                                        bands=['VH', 'VV'],


### PR DESCRIPTION
Addressed an issue where datasets lacking VH polarization were not processed correctly. Added a condition to filter collections with both VV and VH polarizations. This ensures proper data selection and avoids potential errors in downstream processing.