### PR TITLE
Update storage.py

### DIFF
--- a/src/eo_processing/utils/storage.py
+++ b/src/eo_processing/utils/storage.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 if TYPE_CHECKING:
     from eo_processing.config.data_formats import s3_credentials_format
 
-WEED_BUCKETS = ['ecdc', 'model', 'extent', 'test']
+WEED_BUCKETS = ['ecdc', 'model', 'extent', 'test', 'ecdc-stac', 'extent-stac']
 
 class storage:
     """


### PR DESCRIPTION
adding the STAC workspaces to the VITO vault and therefore useable with the storage class. we added extent-stac and ecdc-stac buckets which still give the same S3 buckets but the corrected assosiated export_workspace to directly post the data as STAC catalogs in the WEED STAC api.