### PR TITLE
fix for new openeo filenaming of timeseries.parquet

### DIFF
--- a/src/eo_processing/utils/jobmanager.py
+++ b/src/eo_processing/utils/jobmanager.py
@@ -289,7 +289,7 @@ class WeedJobManager(MultiBackendJobManager):
             if file_ext in ['netcdf','gtiff']:
                 results.download_files(job_dir, include_stac_metadata=False)
             else :
-                results.download_file(job_dir / f"{title}.{file_ext}", name=f"timeseries.{file_ext}")
+                results.download_file(job_dir / f"{title}.{file_ext}")
 
 
         with open(metadata_path, "w", encoding='utf8') as f:


### PR DESCRIPTION
There should only be one asset present, so this should be trouble free. 
The only effect is on direct downloading without storing on (WEED) s3.
